### PR TITLE
xml_find_one() has been deprecated, using xml_find_first()

### DIFF
--- a/R/way_utils.r
+++ b/R/way_utils.r
@@ -22,7 +22,7 @@ process_osm_ways <- function(doc, osm_nodes) {
   # get all the nodes for the ways. this is a list of
   # named vectors
   tmp <- pblapply(xml_find_all(doc, ways_not_nd), function(x) {
-    c(way_id=xml_attr(xml_find_one(x, ".."), "id"),
+    c(way_id=xml_attr(xml_find_first(x, ".."), "id"),
       id=xml_attr(x, "ref"))
   })
   # we can quickly and memory efficiently turn that into a matrix
@@ -62,7 +62,7 @@ osm_ways_to_spldf <- function(doc, osm_ways) {
   }
 
   tmp <- pblapply(xml_find_all(doc, ways_not_tag), function(x) {
-    c(way_id=xml_attr(xml_find_one(x, ".."), "id"),
+    c(way_id=xml_attr(xml_find_first(x, ".."), "id"),
       k=xml_attr(x, "k"),
       v=xml_attr(x, "v"))
   })


### PR DESCRIPTION
Hello,
with version 1.0.0 of xml2 'xml_find_one()' has been deprecated, so now using 'xml_find_first'.

Thank you for the package!
Patrick
